### PR TITLE
return an error instead of crashing when no modems detected

### DIFF
--- a/simple.go
+++ b/simple.go
@@ -3,6 +3,7 @@ package cellmodemd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"github.com/google/renameio"
 	"github.com/maltegrosse/go-modemmanager"
 	"io"
@@ -22,6 +23,8 @@ type simpleConnector struct {
 	conproperties modemmanager.SimpleProperties
 	Bearer        modemmanager.Bearer
 }
+
+var ErrNoModem = errors.New("No modem found")
 
 type SimpleConnector interface {
 	Connect() error
@@ -44,6 +47,9 @@ func (sc *simpleConnector) init(index int) error {
 	modems, err := sc.mmgr.GetModems()
 	if err != nil {
 		return err
+	}
+	if len(modems) == 0 {
+		return ErrNoModem
 	}
 
 	sc.modem = modems[index]


### PR DESCRIPTION
More gracefully handle situation when no modem is found.  Resolves this panic:

```
panic: runtime error: index out of range [0] with length 0
goroutine 1 [running]:
gopkg.in/kainz/cellmodemd%2ev0.(*simpleConnector).init(0x15220e0, 0x0)
        cellmodemd/simple.go:49 +0x1f0
gopkg.in/kainz/cellmodemd%2ev0.GetConnector({0x28a6a0, 0x14980c0}, 0x0, {0xbeab1f48, 0x6}, 0x149c030)
        cellmodemd/simple.go:40 +0xa8
main.main()
        cellmodemd/modemd/main.go:33 +0x300
```